### PR TITLE
Add required fonts

### DIFF
--- a/app/components/appbar.jsx
+++ b/app/components/appbar.jsx
@@ -26,14 +26,6 @@ export default function AppbarGlobal() {
   return (
     <AppBar position='sticky' sx={{ mb: 4}}>
       <Toolbar>
-        {/* <Image
-            src="/logo.png"
-            alt="Our Logo"
-            height={40}
-            width={40}
-            priority
-            
-        /> */}
         <Typography
           variant="h5"
           noWrap
@@ -41,7 +33,7 @@ export default function AppbarGlobal() {
           href="/"
           sx={{
             display: { xs: "none", md: "flex" },
-            fontFamily: "monospace",
+            fontFamily: "Grenze Gotisch",
             fontWeight: 700,
             letterSpacing: ".05rem",
             color: "inherit",

--- a/app/components/footer.jsx
+++ b/app/components/footer.jsx
@@ -27,7 +27,7 @@ export default function FooterGlobal() {
                         noWrap
                         sx={{
                             display: { xs: "none", md: "flex" },
-                            fontFamily: "monospace",
+                            fontFamily: "Grenze Gotisch",
                             fontWeight: 700,
                             letterSpacing: ".05rem",
                             color: theme.palette.primary.main,

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -23,6 +23,9 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" />
+      <link href="https://fonts.googleapis.com/css2?family=Grenze+Gotisch:wght@100..900&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet"></link>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/app/styles/global-theme.jsx
+++ b/app/styles/global-theme.jsx
@@ -27,6 +27,6 @@ export const theme = createTheme({
     },
   },
   typography: {
-    fontFamily: "Arial, sans-serif",
+    fontFamily: "Space Mono, monospace",
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.13.0",
         "@mui/icons-material": "^6.1.4",
         "@mui/material": "^6.1.4",
+        "edutrack": "file:",
         "next": "14.2.15",
         "react": "^18",
         "react-dom": "^18"
@@ -2019,6 +2020,10 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/edutrack": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.1.4",
     "@mui/material": "^6.1.4",
+    "edutrack": "file:",
     "next": "14.2.15",
     "react": "^18",
     "react-dom": "^18"


### PR DESCRIPTION
Description:
This pull request adds two new fonts, Space Mono and Grenze Gotisch. Space Mono is used for the project text, while Grenze Gotisch is designated for the logo.

Changes:
- Added Space Mono and Grenze Gotisch from Google Fonts to the project through a <link> element in the layout.jsx file.
- Updated the global-theme.jsx configuration to incorporate the Space Mono font.
- Modified both appbar.jsx and footer.jsx to use the Grenze Gotisch font for the logo.

Impact:
- These font additions are non-breaking and enhance the visual style in areas where the new fonts are applied.