### PR TITLE
Make Footer Sticky at Bottom of Screen

### DIFF
--- a/app/components/footer.jsx
+++ b/app/components/footer.jsx
@@ -11,163 +11,173 @@ export default function FooterGlobal() {
     const theme = useTheme();
 
     return (
-        <Container maxWidth='100vw' disableGutters
+        <Box
             sx={{
+                position: 'fixed',
+                bottom: 0,
+                width: '100%',
                 backgroundColor: theme.palette.secondary.main,
+                zIndex: 1000, // Ensure the footer is above other elements
             }}
         >
-            <Container maxWidth='md'>
-                <Grid container >
-                    
-                    {/*LEFT COLUMN */}
-                    <Grid size={{xs: 12, md: 6}} color={theme.palette.primary.main}
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            alignItems: 'center'
-                        }}
-                    >
-                        <Box
+            <Container maxWidth='100vw' disableGutters
+                sx={{
+                    backgroundColor: theme.palette.secondary.main,
+                }}
+            >
+                <Container maxWidth='md'>
+                    <Grid container >
+                        
+                        {/*LEFT COLUMN */}
+                        <Grid size={{xs: 12, md: 6}} color={theme.palette.primary.main}
                             sx={{
-                                mt: 6,
-                                mb: {
-                                    xs: 2,
-                                    md: 6
-                                },
-                                textAlign: {
-                                    xs: 'center',
-                                    md: 'left'
-                                }
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'center'
                             }}
                         >
-                            <Box display='flex'
+                            <Box
                                 sx={{
-                                    mb: 3,
-                                    display: 'flex',
-                                    justifyContent: {
+                                    mt: 6,
+                                    mb: {
+                                        xs: 2,
+                                        md: 6
+                                    },
+                                    textAlign: {
                                         xs: 'center',
                                         md: 'left'
                                     }
                                 }}
                             >
-                                <Typography component={Link} href='/about' color={theme.palette.primary.main}
-                                    sx={{textDecoration: 'none'}}
+                                <Box display='flex'
+                                    sx={{
+                                        mb: 3,
+                                        display: 'flex',
+                                        justifyContent: {
+                                            xs: 'center',
+                                            md: 'left'
+                                        }
+                                    }}
                                 >
-                                    BRAND
+                                    <Typography component={Link} href='/about' color={theme.palette.primary.main}
+                                        sx={{textDecoration: 'none'}}
+                                    >
+                                        BRAND
+                                    </Typography>
+                                    <Typography component={Link} href='/contact' color={theme.palette.primary.main}
+                                        sx={{ml: 5, textDecoration: 'none'}}
+                                    >
+                                        CONTACT
+                                    </Typography>
+                                </Box>
+                                <Typography component={Link} href='/shipment' color={theme.palette.primary.main}
+                                    sx={{mb: 3, textDecoration: 'none', display: 'block'}}
+                                >
+                                    SHIPPING AND CHANGES
                                 </Typography>
-                                <Typography component={Link} href='/contact' color={theme.palette.primary.main}
-                                    sx={{ml: 5, textDecoration: 'none'}}
+                                <Typography component={Link} href='/faq' color={theme.palette.primary.main}
+                                    sx={{mb: 3, textDecoration: 'none', display: 'block'}}
                                 >
-                                    CONTACT
+                                    FREQUENT ASKED QUESTIONS
+                                </Typography >
+                                <Typography component={Link} href='/terms' color={theme.palette.primary.main}
+                                    sx={{mb: 3, textDecoration: 'none', display: 'block'}}
+                                >
+                                    TERMS AND CONDITIONS
                                 </Typography>
                             </Box>
-                            <Typography component={Link} href='/shipment' color={theme.palette.primary.main}
-                                sx={{mb: 3, textDecoration: 'none', display: 'block'}}
-                            >
-                                SHIPPING AND CHANGES
-                            </Typography>
-                            <Typography component={Link} href='/faq' color={theme.palette.primary.main}
-                                sx={{mb: 3, textDecoration: 'none', display: 'block'}}
-                            >
-                                FREQUENT ASKED QUESTIONS
-                            </Typography >
-                            <Typography component={Link} href='/terms' color={theme.palette.primary.main}
-                                sx={{mb: 3, textDecoration: 'none', display: 'block'}}
-                            >
-                                TERMS AND CONDITIONS
-                            </Typography>
-                        </Box>
-                    </Grid>
-                    
-                    {/*RIGHT COLUMN */}
-                    <Grid size={{xs: 12, md: 6}} color={theme.palette.primary.main}
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            alignItems: {
-                                xs: 'center',
-                                md: 'end'
-                            }
-                        }}
-                    >
-                        <Box
+                        </Grid>
+                        
+                        {/*RIGHT COLUMN */}
+                        <Grid size={{xs: 12, md: 6}} color={theme.palette.primary.main}
                             sx={{
-                                my: {
-                                    xs: 4,
-                                    md: 6
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: {
+                                    xs: 'center',
+                                    md: 'end'
                                 }
                             }}
                         >
-                            <Typography
-                                variant="h5"
-                                noWrap
-                                component={Link}
-                                href="/"
+                            <Box
                                 sx={{
-                                    fontFamily: "Grenze Gotisch",
-                                    fontWeight: 600,
-                                    letterSpacing: ".05rem",
-                                    color: "inherit",
-                                    textDecoration: "none",
-                                }}
-                            >
-                                TiendaRopa
-                            </Typography>
-
-                            <Box sx={{mt: 1.5, width: 112}}>
-                                <IconButton sx={{color: theme.palette.primary.main, p: 0, mr: 2, ml: 1}}>
-                                    <TwitterIcon/>
-                                </IconButton>
-                                <IconButton sx={{color: theme.palette.primary.main, p: 0, mr: 2}}>
-                                    <InstagramIcon />
-                                </IconButton>
-                                <IconButton sx={{color: theme.palette.primary.main, p: 0}}>
-                                    <FacebookIcon />
-                                </IconButton>
-                            </Box>
-                        </Box>
-
-                        <Box
-                            sx={{
-                                mb: {
-                                    xs: 6,
-                                    md: 0
-                                }
-                            }}
-                        >
-                            <Typography variant="subtitle2"
-                                sx={{
-                                    fontSize: 10,
-                                    textAlign: {
-                                        md: 'right',
-                                        xs: 'center'
+                                    my: {
+                                        xs: 4,
+                                        md: 6
                                     }
                                 }}
                             >
-                                Receive news from TiendaRopa
-                            </Typography>
-                            <TextField 
-                                placeholder="Your email"
-                                variant="standard"
-                                size="small"
-                                
+                                <Typography
+                                    variant="h5"
+                                    noWrap
+                                    component={Link}
+                                    href="/"
+                                    sx={{
+                                        fontFamily: "Grenze Gotisch",
+                                        fontWeight: 600,
+                                        letterSpacing: ".05rem",
+                                        color: "inherit",
+                                        textDecoration: "none",
+                                    }}
+                                >
+                                    TiendaRopa
+                                </Typography>
+
+                                <Box sx={{mt: 1.5, width: 112}}>
+                                    <IconButton sx={{color: theme.palette.primary.main, p: 0, mr: 2, ml: 1}}>
+                                        <TwitterIcon/>
+                                    </IconButton>
+                                    <IconButton sx={{color: theme.palette.primary.main, p: 0, mr: 2}}>
+                                        <InstagramIcon />
+                                    </IconButton>
+                                    <IconButton sx={{color: theme.palette.primary.main, p: 0}}>
+                                        <FacebookIcon />
+                                    </IconButton>
+                                </Box>
+                            </Box>
+
+                            <Box
                                 sx={{
-                                    border: '1px solid white',
-                                    '& .MuiInputBase-input': { //Placeholder text
-                                        color: 'white',
-                                        textAlign: {
-                                            xs: 'center',
-                                            md: 'right'
-                                        } 
-                                    },
+                                    mb: {
+                                        xs: 6,
+                                        md: 0
+                                    }
                                 }}
-                            />
-                        </Box>
+                            >
+                                <Typography variant="subtitle2"
+                                    sx={{
+                                        fontSize: 10,
+                                        textAlign: {
+                                            md: 'right',
+                                            xs: 'center'
+                                        }
+                                    }}
+                                >
+                                    Receive news from TiendaRopa
+                                </Typography>
+                                <TextField 
+                                    placeholder="Your email"
+                                    variant="standard"
+                                    size="small"
+                                    
+                                    sx={{
+                                        border: '1px solid white',
+                                        '& .MuiInputBase-input': { //Placeholder text
+                                            color: 'white',
+                                            textAlign: {
+                                                xs: 'center',
+                                                md: 'right'
+                                            } 
+                                        },
+                                    }}
+                                />
+                            </Box>
+                        </Grid>
+
                     </Grid>
 
-                </Grid>
-
+                </Container>
             </Container>
-        </Container>
+        </Box>
     );
 }


### PR DESCRIPTION
Description:
This pull request updates the footer component to ensure it remains fixed at the bottom of the screen across all pages.

Changes:
Updated footer styling to make it "sticky," ensuring it stays at the bottom of the viewport.

Impact:
This update ensures that the footer is consistently visible at the bottom.

Testing:
- Verify that the footer stays at the bottom of the screen on both short and long pages.
- Check that the footer's position remains stable and does not overlap with other content.